### PR TITLE
Added cooldown player actions

### DIFF
--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/PlayerActionRule.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/PlayerActionRule.java
@@ -12,10 +12,10 @@ import java.util.Arrays;
 
 public class PlayerActionRule<T extends IPlayerElement> implements IPlayerRule<T> {
 
-    private final String name;
-    private final IVarTriPredicate<State, T, Object> predicate;
-    private final IVarTriConsumer<State, T, Object> consumer;
-    private final TypeRange<?>[] parameters;
+    protected final String name;
+    protected final IVarTriPredicate<State, T, Object> predicate;
+    protected final IVarTriConsumer<State, T, Object> consumer;
+    protected final TypeRange<?>[] parameters;
 
     public PlayerActionRule(String name, IVarTriPredicate<State, T, Object> predicate, IVarTriConsumer<State, T, Object> consumer, TypeRange<?>... parameters) {
         this.name = name;
@@ -59,7 +59,7 @@ public class PlayerActionRule<T extends IPlayerElement> implements IPlayerRule<T
         return parameters;
     }
 
-    private boolean validateOptionalTypes(Object[] meta) {
+    protected boolean validateOptionalTypes(Object[] meta) {
         if (meta.length != parameters.length) {
             return false;
         }

--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/TimedPlayerActionRule.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/TimedPlayerActionRule.java
@@ -1,0 +1,55 @@
+package pro.trevor.tankgame.rule.definition.player;
+
+import org.json.JSONObject;
+import pro.trevor.tankgame.rule.type.ICooldownPlayerElement;
+import pro.trevor.tankgame.state.State;
+import pro.trevor.tankgame.util.IJsonObject;
+import pro.trevor.tankgame.util.function.IVarTriConsumer;
+import pro.trevor.tankgame.util.function.IVarTriPredicate;
+import pro.trevor.tankgame.util.range.TypeRange;
+
+import java.util.function.Function;
+
+public class TimedPlayerActionRule<T extends ICooldownPlayerElement> extends PlayerActionRule<T> {
+
+    // Returns the cooldown in milliseconds for the function based on the state
+    private final Function<State, Long> cooldownFunction;
+
+    public TimedPlayerActionRule(String name, IVarTriPredicate<State, T, Object> predicate, IVarTriConsumer<State, T, Object> consumer, Function<State, Long> cooldownFunction, TypeRange<?>... parameters) {
+        super(name, predicate, consumer, parameters);
+        this.cooldownFunction = cooldownFunction;
+    }
+
+    @Override
+    public void apply(State state, T subject, Object... meta) {
+        long cooldown = cooldownFunction.apply(state);
+        long elapsed = System.currentTimeMillis() - subject.getLastUsage(name);
+        if (elapsed >= cooldown) {
+            super.apply(state, subject, meta);
+            subject.setLastUsage(name, System.currentTimeMillis());
+        } else {
+            JSONObject error = new JSONObject();
+            error.put("error", true);
+            error.put("rule", name);
+            error.put("cooldown", cooldown);
+            error.put("elapsed", elapsed);
+
+            if (subject instanceof IJsonObject subjectJson) {
+                error.put("subject", subjectJson.toJson());
+            } else {
+                error.put("subject", subject.getPlayer());
+            }
+
+            System.err.println(error.toString(2));
+            throw new Error(String.format("Rule %s has cooldown of %dms but only waited %dms", name, cooldown, elapsed));
+        }
+    }
+
+    @Override
+    public boolean canApply(State state, T subject, Object... meta) {
+        long cooldown = cooldownFunction.apply(state);
+        long elapsed = System.currentTimeMillis() - subject.getLastUsage(name);
+        return elapsed >= cooldown && super.canApply(state, subject, meta);
+    }
+
+}

--- a/src/main/java/pro/trevor/tankgame/rule/type/ICooldownPlayerElement.java
+++ b/src/main/java/pro/trevor/tankgame/rule/type/ICooldownPlayerElement.java
@@ -1,0 +1,11 @@
+package pro.trevor.tankgame.rule.type;
+
+public interface ICooldownPlayerElement extends IPlayerElement {
+
+    // Returns the time in milliseconds since epoch of the last usage of the specified rule or 0 if it has not been used
+    long getLastUsage(String rule);
+
+    // Sets the time last used of the specified rule to the given time in milliseconds since epoch
+    void setLastUsage(String rule, long time);
+
+}


### PR DESCRIPTION
Adds an action type that can be used on a player element that implements a cooldown mechanism. The cooldown is given as a function of the game state so it can be made static (e.g., always 5 minutes) or dynamic (e.g., 5 minutes when 10+ players are alive, 10 minutes when fewer than 10 players are alive).