### PR TITLE
Global Cooldown Tank

### DIFF
--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/TimedPlayerActionRule.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/TimedPlayerActionRule.java
@@ -20,6 +20,11 @@ public class TimedPlayerActionRule<T extends ICooldownPlayerElement> extends Pla
         this.cooldownFunction = cooldownFunction;
     }
 
+    public TimedPlayerActionRule(PlayerActionRule<T> rule, Function<State, Long> cooldownFunction) {
+        super(rule.name, rule.predicate, rule.consumer, rule.parameters);
+        this.cooldownFunction = cooldownFunction;
+    }
+
     @Override
     public void apply(State state, T subject, Object... meta) {
         long cooldown = cooldownFunction.apply(state);

--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/TimedPlayerActionRule.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/TimedPlayerActionRule.java
@@ -15,7 +15,7 @@ public class TimedPlayerActionRule<T extends ICooldownPlayerElement> extends Pla
     // Returns the cooldown in milliseconds for the function based on the state
     private final Function<State, Long> cooldownFunction;
 
-    public TimedPlayerActionRule(String name, IVarTriPredicate<State, T, Object> predicate, IVarTriConsumer<State, T, Object> consumer, Function<State, Long> cooldownFunction, TypeRange<?>... parameters) {
+    public TimedPlayerActionRule(String name, Function<State, Long> cooldownFunction, IVarTriPredicate<State, T, Object> predicate, IVarTriConsumer<State, T, Object> consumer, TypeRange<?>... parameters) {
         super(name, predicate, consumer, parameters);
         this.cooldownFunction = cooldownFunction;
     }

--- a/src/main/java/pro/trevor/tankgame/state/board/unit/GlobalCooldownTank.java
+++ b/src/main/java/pro/trevor/tankgame/state/board/unit/GlobalCooldownTank.java
@@ -1,0 +1,43 @@
+package pro.trevor.tankgame.state.board.unit;
+
+import org.json.JSONObject;
+import pro.trevor.tankgame.rule.type.ICooldownPlayerElement;
+import pro.trevor.tankgame.state.board.Position;
+import pro.trevor.tankgame.state.board.attribute.IAttribute;
+
+import java.util.Map;
+
+/**
+ * A generic cooldown tank that has one cooldown shared across all actions. Actions still each define their cooldowns
+ * individually.
+ * @param <E> The attribute enum to be used for storing attributes about the tank.
+ */
+public class GlobalCooldownTank<E extends Enum<E> & IAttribute> extends GenericTank<E> implements ICooldownPlayerElement {
+
+    protected long lastActionTime;
+
+    public GlobalCooldownTank(String player, Position position, Map<E, Object> defaults) {
+        super(player, position, defaults);
+        this.lastActionTime = 0;
+    }
+
+    public GlobalCooldownTank(JSONObject json, Class<E> type) {
+        super(json, type);
+        this.lastActionTime = json.optLong("last_action_time", 0);
+    }
+
+    @Override
+    public long getLastUsage(String rule) {
+        return lastActionTime;
+    }
+
+    @Override
+    public void setLastUsage(String rule, long time) {
+        this.lastActionTime = time;
+    }
+
+    @Override
+    public JSONObject toJson() {
+        return super.toJson().put("last_action_time", lastActionTime);
+    }
+}


### PR DESCRIPTION
Added a generic tank type which can be used in TimedPlayerActionRules but only has one cooldown. This allows for a tank to have their cooldown reset on any action, but each action can still have individually-defined cooldowns.