### PR TITLE
RulePredicate with Optionals and better Error Handling

### DIFF
--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/AttributePredicate.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/AttributePredicate.java
@@ -1,22 +1,15 @@
 package pro.trevor.tankgame.rule.definition.player.conditional;
 
-import pro.trevor.tankgame.rule.type.IPlayerElement;
 import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.state.attribute.AttributeContainer;
 import pro.trevor.tankgame.state.meta.PlayerRef;
-import pro.trevor.tankgame.util.Result;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 public class AttributePredicate<T extends AttributeContainer> extends GetterPredicate<T> {
-
-    public AttributePredicate(BiFunction<State, PlayerRef, T> getter, Function<T, Result<String>> predicate) {
-        super(getter, (s, t, n) -> predicate.apply(t));
-    }
-
-    public AttributePredicate(BiFunction<State, PlayerRef, T> getter, Predicate<T> predicate, String error) {
-        super(getter, (s, t, n) -> predicate.test(t) ? Result.ok() : Result.error(error));
+    public AttributePredicate(BiFunction<State, PlayerRef, Optional<T>> getter, Predicate<T> predicate, String error) {
+        super(getter, (state, t, n) -> predicate.test(t), error);
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/BooleanPredicate.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/BooleanPredicate.java
@@ -5,11 +5,11 @@ import pro.trevor.tankgame.state.attribute.Attribute;
 import pro.trevor.tankgame.state.attribute.AttributeContainer;
 import pro.trevor.tankgame.state.meta.PlayerRef;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 public class BooleanPredicate<T extends AttributeContainer> extends AttributePredicate<T> {
-
-    public BooleanPredicate(BiFunction<State, PlayerRef, T> getter, Attribute<Boolean> attribute, boolean expected, String error) {
+    public BooleanPredicate(BiFunction<State, PlayerRef, Optional<T>> getter, Attribute<Boolean> attribute, boolean expected, String error) {
         super(getter, (t) -> t.has(attribute) && t.getUnsafe(attribute).equals(expected), error);
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/GetterPredicate.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/GetterPredicate.java
@@ -3,19 +3,16 @@ package pro.trevor.tankgame.rule.definition.player.conditional;
 import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.state.attribute.AttributeContainer;
 import pro.trevor.tankgame.state.meta.PlayerRef;
-import pro.trevor.tankgame.util.Result;
-import pro.trevor.tankgame.util.function.IVarTriFunction;
 import pro.trevor.tankgame.util.function.IVarTriPredicate;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 public class GetterPredicate<T extends AttributeContainer> extends RulePredicate {
-
-    public GetterPredicate(BiFunction<State, PlayerRef, T> getter, IVarTriFunction<State, T, Object, Result<String>> predicate) {
-        super((s, p, n) -> predicate.accept(s, getter.apply(s, p), n));
-    }
-
-    public GetterPredicate(BiFunction<State, PlayerRef, T> getter, IVarTriPredicate<State, T, Object> predicate, String message) {
-        super((s, p, n) -> predicate.test(s, getter.apply(s, p), n), message);
+    public GetterPredicate(BiFunction<State, PlayerRef, Optional<T>> getter, IVarTriPredicate<State, T, Object> predicate, String message) {
+        super((state, player, n) -> {
+            Optional<T> optionalT = getter.apply(state, player);
+            return optionalT.isPresent() && predicate.test(state, optionalT.get(), n);
+        }, message);
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/MaximumPredicate.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/MaximumPredicate.java
@@ -1,16 +1,15 @@
 package pro.trevor.tankgame.rule.definition.player.conditional;
 
-import pro.trevor.tankgame.rule.type.IPlayerElement;
 import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.state.attribute.Attribute;
 import pro.trevor.tankgame.state.attribute.AttributeContainer;
 import pro.trevor.tankgame.state.meta.PlayerRef;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
 
-public class MaximumPredicate<A extends Comparable<A>, T extends AttributeContainer & IPlayerElement> extends AttributePredicate<T> {
-
-    public MaximumPredicate(BiFunction<State, PlayerRef, T> getter, Attribute<A> attribute, A bound, String error) {
+public class MaximumPredicate<A extends Comparable<A>, T extends AttributeContainer> extends AttributePredicate<T> {
+    public MaximumPredicate(BiFunction<State, PlayerRef, Optional<T>> getter, Attribute<A> attribute, A bound, String error) {
         super(getter, (t) -> (t.has(attribute) && t.getUnsafe(attribute).compareTo(bound) <= 0), error);
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/MinimumPredicate.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/MinimumPredicate.java
@@ -1,16 +1,15 @@
 package pro.trevor.tankgame.rule.definition.player.conditional;
 
-import pro.trevor.tankgame.rule.type.IPlayerElement;
 import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.state.attribute.Attribute;
 import pro.trevor.tankgame.state.attribute.AttributeContainer;
 import pro.trevor.tankgame.state.meta.PlayerRef;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
 
-public class MinimumPredicate<A extends Comparable<A>, T extends AttributeContainer & IPlayerElement> extends AttributePredicate<T> {
-
-    public MinimumPredicate(BiFunction<State, PlayerRef, T> getter, Attribute<A> attribute, A bound, String error) {
+public class MinimumPredicate<A extends Comparable<A>, T extends AttributeContainer> extends AttributePredicate<T> {
+    public MinimumPredicate(BiFunction<State, PlayerRef, Optional<T>> getter, Attribute<A> attribute, A bound, String error) {
         super(getter, (t) -> (t.has(attribute) && t.getUnsafe(attribute).compareTo(bound) >= 0), error);
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/OptionalGetterPredicate.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/OptionalGetterPredicate.java
@@ -1,0 +1,14 @@
+package pro.trevor.tankgame.rule.definition.player.conditional;
+
+import pro.trevor.tankgame.state.State;
+import pro.trevor.tankgame.state.meta.PlayerRef;
+import pro.trevor.tankgame.util.function.IVarTriPredicate;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public class OptionalGetterPredicate<T> extends RulePredicate {
+    public OptionalGetterPredicate(BiFunction<State, PlayerRef, Optional<T>> getter, IVarTriPredicate<State, Optional<T>, Object> predicate, String message) {
+        super((s, p, n) -> predicate.test(s, getter.apply(s, p), n), message);
+    }
+}

--- a/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/UncheckedGetterPredicate.java
+++ b/src/main/java/pro/trevor/tankgame/rule/definition/player/conditional/UncheckedGetterPredicate.java
@@ -1,0 +1,21 @@
+package pro.trevor.tankgame.rule.definition.player.conditional;
+
+import pro.trevor.tankgame.state.State;
+import pro.trevor.tankgame.state.attribute.AttributeContainer;
+import pro.trevor.tankgame.state.meta.PlayerRef;
+import pro.trevor.tankgame.util.Result;
+import pro.trevor.tankgame.util.function.IVarTriFunction;
+import pro.trevor.tankgame.util.function.IVarTriPredicate;
+
+import java.util.function.BiFunction;
+
+public class UncheckedGetterPredicate<T extends AttributeContainer> extends RulePredicate {
+
+    public UncheckedGetterPredicate(BiFunction<State, PlayerRef, T> getter, IVarTriFunction<State, T, Object, Result<String>> predicate) {
+        super((s, p, n) -> predicate.accept(s, getter.apply(s, p), n));
+    }
+
+    public UncheckedGetterPredicate(BiFunction<State, PlayerRef, T> getter, IVarTriPredicate<State, T, Object> predicate, String message) {
+        super((s, p, n) -> predicate.test(s, getter.apply(s, p), n), message);
+    }
+}

--- a/src/test/java/pro/trevor/tankgame/rule/BuyActionWithGoldTest.java
+++ b/src/test/java/pro/trevor/tankgame/rule/BuyActionWithGoldTest.java
@@ -113,7 +113,7 @@ public class BuyActionWithGoldTest {
                 .with(Attribute.GOLD, startingGold).with(Attribute.DEAD, false).finish();
 
         IPlayerRule rule = PlayerRules.buyActionWithGold(3, 5);
-        rule.apply(TestUtilities.generateBoard(1, 1, tank), new PlayerRef("test"), spentGold);
+        rule.apply(TestUtilities.generateBoard(1, 1, tank), tank.getPlayerRef(), spentGold);
 
         assertEquals(expectedGold, tank.getUnsafe(Attribute.GOLD));
         assertEquals(expectedActions, tank.getUnsafe(Attribute.ACTION_POINTS));
@@ -133,7 +133,7 @@ public class BuyActionWithGoldTest {
                 .with(Attribute.DEAD, false).finish();
 
         IPlayerRule rule = PlayerRules.buyActionWithGold(actionCost, 5);
-        rule.apply(TestUtilities.generateBoard(1, 1, tank), new PlayerRef("test"), goldSpent);
+        rule.apply(TestUtilities.generateBoard(1, 1, tank), tank.getPlayerRef(), goldSpent);
 
         assertEquals(0, tank.getUnsafe(Attribute.GOLD));
         assertEquals(expectedActions, tank.getUnsafe(Attribute.ACTION_POINTS));

--- a/src/test/java/pro/trevor/tankgame/state/DestructibleFloorTest.java
+++ b/src/test/java/pro/trevor/tankgame/state/DestructibleFloorTest.java
@@ -23,8 +23,7 @@ import pro.trevor.tankgame.util.TestUtilities;
 
 public class DestructibleFloorTest {
 
-    private DestructibleFloor GetTestFloor(Position position, int durability, int maxDurability)
-    {
+    private DestructibleFloor GetTestFloor(Position position, int durability, int maxDurability) {
         assert durability >= 0;
         return new DestructibleFloor(position, durability, maxDurability);
     }
@@ -96,7 +95,7 @@ public class DestructibleFloorTest {
         s.getBoard().putFloor(floor);
 
         IPlayerRule shootRule = PlayerRules.SHOOT_V4;
-        boolean canShoot = shootRule.canApply(s, new PlayerRef("test"), new Position("B1"), true);
+        boolean canShoot = shootRule.canApply(s, t.getPlayerRef(), new Position("B1"), true);
         shootRule.apply(s, t.getPlayerRef(), new Position("B1"), true);
 
         assertTrue(canShoot);
@@ -114,18 +113,18 @@ public class DestructibleFloorTest {
         IPlayerRule moveRule = PlayerRules.getMoveRule(Attribute.ACTION_POINTS, 1);
 
         // Move onto destructible floor, then move past it
-        moveRule.apply(s, new PlayerRef("test"), new Position("B1"));
+        moveRule.apply(s, t.getPlayerRef(), new Position("B1"));
         assertEquals(t.getPosition(), floor.getPosition());
-        moveRule.apply(s, new PlayerRef("test"), new Position("C1"));
+        moveRule.apply(s, t.getPlayerRef(), new Position("C1"));
 
         // Shoot at the destructible floor, destroying it
-        shootRule.apply(s, new PlayerRef("test"), new Position("B1"), true);
+        shootRule.apply(s, t.getPlayerRef(), new Position("B1"), true);
         assertEquals(0, floor.getUnsafe(Attribute.DURABILITY));
         assertTrue(floor.get(Attribute.DESTROYED).orElse(false));
 
         // Try to move onto the broken floor, you cannot
-        assertFalse(moveRule.canApply(s, new PlayerRef("test"), new Position("B1")));
-        assertThrows(Error.class, () -> moveRule.apply(s, new PlayerRef("test"), new Position("B1")));
+        assertFalse(moveRule.canApply(s, t.getPlayerRef(), new Position("B1")));
+        assertThrows(Error.class, () -> moveRule.apply(s, t.getPlayerRef(), new Position("B1")));
     }
 
     @Test
@@ -140,7 +139,7 @@ public class DestructibleFloorTest {
 
         IPlayerRule shootRule = PlayerRules.SHOOT_V4;
         ConditionalRule<GenericTank> dieOrDestroyRule = ConditionalRules.GetKillOrDestroyTankOnZeroDurabilityRule();
-        shootRule.apply(s, new PlayerRef("test"), new Position("B1"), true);
+        shootRule.apply(s, t.getPlayerRef(), new Position("B1"), true);
         dieOrDestroyRule.apply(s, t);
         dieOrDestroyRule.apply(s, tankAbove);
 
@@ -165,7 +164,7 @@ public class DestructibleFloorTest {
         IPlayerRule moveRule = PlayerRules.getMoveRule(Attribute.ACTION_POINTS, 1);
 
         // Shoot once, destroying the wall
-        shootRule.apply(s, new PlayerRef("test"), new Position("B1"), true);
+        shootRule.apply(s, t.getPlayerRef(), new Position("B1"), true);
         destroyWallRule.apply(s, wall);
 
         // Floor durability is unchanged
@@ -173,14 +172,14 @@ public class DestructibleFloorTest {
         assertFalse(floor.get(Attribute.DESTROYED).orElse(false));
 
         //Shoot again
-        shootRule.apply(s, new PlayerRef("test"), new Position("B1"), true);
+        shootRule.apply(s, t.getPlayerRef(), new Position("B1"), true);
 
         // Floor is destroyed
         assertEquals(0, floor.getUnsafe(Attribute.DURABILITY));
         assertTrue(floor.get(Attribute.DESTROYED).orElse(false));
 
         // Try to move onto the broken floor, you cannot
-        assertFalse(moveRule.canApply(s, new PlayerRef("test"), new Position("B1")));
-        assertThrows(Error.class, () -> moveRule.apply(s, new PlayerRef("test"), new Position("B1")));
+        assertFalse(moveRule.canApply(s, t.getPlayerRef(), new Position("B1")));
+        assertThrows(Error.class, () -> moveRule.apply(s, t.getPlayerRef(), new Position("B1")));
     }
 }

--- a/src/test/java/pro/trevor/tankgame/util/TankBuilder.java
+++ b/src/test/java/pro/trevor/tankgame/util/TankBuilder.java
@@ -30,9 +30,12 @@ public class TankBuilder<T extends GenericTank> {
         return tank;
     }
 
+
+    private static int count = 0;
+
     public static TankBuilder<GenericTank> buildTank() {
         GenericTank tank = new GenericTank(
-            new PlayerRef("test"),
+            new PlayerRef("test " + count),
             new Position("A1"),
             Map.of(
                 Attribute.DEAD, false,


### PR DESCRIPTION
* Renamed GetterPredicate to UncheckedGetterPredicate.
* Added GetterPredicate which accepts a producer of Optional<T> and returns the error message when empty.
* Added OptionalGetterPredicate which allows the user to handle the empty Optional<T> case above.
* Refactored other Predicates and rules to utilize GetterPredicate and OptionalPredicate.